### PR TITLE
Fix missing wonders

### DIFF
--- a/RoundSquare.tilespec
+++ b/RoundSquare.tilespec
@@ -175,6 +175,7 @@ files =
   "RoundSquare/nuke.spec",
   "RoundSquare/explosions.spec",
   "misc/buildings.spec",
+  "misc/wonders.spec",
   "misc/space.spec",
   "misc/techs.spec",
   "misc/treaty.spec",


### PR DESCRIPTION
Reference `misc/wonders.spec` to fix the display of wonders in the science tree and the city build dialog.

Playing LT82 I noticed these magenta squares in the UI, where in other tilesets wonders are displayed. This fixed that issue for me.

I don't know if this is Freeciv21 specific, that's why I didn't open a PR upstream.